### PR TITLE
Fixes to color casting

### DIFF
--- a/stylesheets/color/helpers/_hex-to-dec.scss
+++ b/stylesheets/color/helpers/_hex-to-dec.scss
@@ -10,9 +10,9 @@
   $decimal: 0;
 
   @for $i from 1 through $length {
-    $factor: 1 + (length($hex) * ($length - $i));
-    $index: index($hex, str-slice($string, $i, $i));
-    $decimal: $decimal + $factor * ($index - 1);
+    $factor: _sc-pow(length($hex), ($length - $i));
+    $index: index($hex, str-slice($string, $i, $i)) - 1;
+    $decimal: $decimal + ($factor * $index);
   }
 
   @return $decimal;

--- a/stylesheets/number/helpers/_pow.scss
+++ b/stylesheets/number/helpers/_pow.scss
@@ -6,7 +6,7 @@
 @function _sc-pow($x, $n) {
   $ret: 1;
 
-  @if $n >= 0 {
+  @if $n > 0 {
     @for $i from 1 through $n {
       $ret: ($ret * $x);
     }


### PR DESCRIPTION
I know this repository is marked as unmaintained but I was hoping you would consider this PR. This library right now has two bugs that are causing me problems:

1. `_sc-pow()` doesn't handle the power of 0 correctly
2. `_sc-hex-to-dec` calculates the hex equivalent of a hexadecimal completely wrong; this bug causes the `to-color()` function change the color.
   - e.g. `e0` is calculated as 238 when it really should be 224

Here are two snippets showing what I mean:

git master: https://www.sassmeister.com/gist/f59a56e001aeced7549648e1576516f6
my fixes: https://www.sassmeister.com/gist/855ebd982cb19f5b37ea45409b71a602